### PR TITLE
Add Google and Facebook OAuth login

### DIFF
--- a/ChatRoom/ChatRoom.csproj
+++ b/ChatRoom/ChatRoom.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="5.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="5.0.17" />
   </ItemGroup>
 
 </Project>

--- a/ChatRoom/Controllers/AccountController.cs
+++ b/ChatRoom/Controllers/AccountController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace ChatRoom.Controllers
+{
+    public class AccountController : Controller
+    {
+        [HttpGet]
+        public IActionResult Login(string provider, string returnUrl = "/")
+        {
+            if (string.IsNullOrEmpty(provider))
+            {
+                return BadRequest();
+            }
+            var redirectUrl = Url.Action(nameof(LoginCallback), new { returnUrl });
+            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            return Challenge(properties, provider);
+        }
+
+        public async Task<IActionResult> LoginCallback(string returnUrl = "/")
+        {
+            return LocalRedirect(returnUrl);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Logout()
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/ChatRoom/Startup.cs
+++ b/ChatRoom/Startup.cs
@@ -3,6 +3,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Authentication.Facebook;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
@@ -26,6 +29,24 @@ namespace ChatRoom
         {
             services.AddControllersWithViews();
             services.AddSignalR();
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            })
+            .AddCookie()
+            .AddGoogle(options =>
+            {
+                var google = Configuration.GetSection("Authentication:Google");
+                options.ClientId = google["ClientId"];
+                options.ClientSecret = google["ClientSecret"];
+            })
+            .AddFacebook(options =>
+            {
+                var facebook = Configuration.GetSection("Authentication:Facebook");
+                options.AppId = facebook["AppId"];
+                options.AppSecret = facebook["AppSecret"];
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -46,6 +67,7 @@ namespace ChatRoom
 
             app.UseRouting();
 
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>

--- a/ChatRoom/Views/Shared/_Layout.cshtml
+++ b/ChatRoom/Views/Shared/_Layout.cshtml
@@ -25,6 +25,28 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>
+                    <ul class="navbar-nav">
+                        @if (User.Identity.IsAuthenticated)
+                        {
+                            <li class="nav-item">
+                                <span class="navbar-text text-dark mr-2">Hello @User.Identity.Name!</span>
+                            </li>
+                            <li class="nav-item">
+                                <form asp-controller="Account" asp-action="Logout" method="post" class="form-inline">
+                                    <button type="submit" class="nav-link btn btn-link">Logout</button>
+                                </form>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Account" asp-action="Login" asp-route-provider="Google">Login with Google</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Account" asp-action="Login" asp-route-provider="Facebook">Login with Facebook</a>
+                            </li>
+                        }
+                    </ul>
                 </div>
             </div>
         </nav>

--- a/ChatRoom/appsettings.json
+++ b/ChatRoom/appsettings.json
@@ -6,5 +6,15 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Authentication": {
+    "Google": {
+      "ClientId": "YOUR_GOOGLE_CLIENT_ID",
+      "ClientSecret": "YOUR_GOOGLE_CLIENT_SECRET"
+    },
+    "Facebook": {
+      "AppId": "YOUR_FACEBOOK_APP_ID",
+      "AppSecret": "YOUR_FACEBOOK_APP_SECRET"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
 - `wwwroot/` – 前端使用的靜態檔案。
 
 本範例可作為學習 ASP.NET Core 及 SignalR 即時通訊的起點。
+
+## OAuth 設定
+
+範例已整合 Google 與 Facebook OAuth 登入，需在 `appsettings.json` 中填入對應的
+`ClientId`、`ClientSecret` 或 `AppId`、`AppSecret` 後才能正常使用。


### PR DESCRIPTION
## Summary
- add Google and Facebook auth packages
- configure external authentication in Startup
- provide OAuth settings in appsettings.json
- implement AccountController for login/logout
- update layout with login buttons
- mention OAuth setup in README

## Testing
- `dotnet build ChatRoom.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9323f9083298db4ced0e32e3df2